### PR TITLE
change dependency bounds on hspec

### DIFF
--- a/streaming-process.cabal
+++ b/streaming-process.cabal
@@ -48,7 +48,7 @@ test-suite simple-processes
   build-depends:       streaming-process
                      , base
                      , bytestring
-                     , hspec == 2.4.*
+                     , hspec >= 2.4 && < 2.8
                      , QuickCheck == 2.*
                      , quickcheck-instances
                      , streaming


### PR DESCRIPTION
Loosend the dependency bounds on hspec since the test cases work with
verion 2.7.1